### PR TITLE
fixed issue in query adapter's queryList where CompoundSelectStatemen…

### DIFF
--- a/floor/lib/src/adapter/query_adapter.dart
+++ b/floor/lib/src/adapter/query_adapter.dart
@@ -44,7 +44,7 @@ class QueryAdapter {
   }) async {
     final rootNode = _parseRootNode(sql);
 
-    if (rootNode is SelectStatement) {
+    if (rootNode is BaseSelectStatement) {
       return _database
           .rawQuery(sql, arguments)
           .then((rows) => rows.map((row) => mapper(row)).toList());


### PR DESCRIPTION
…t is not executed

queryList does not allow compound select statements to be executed. UNION queries throw state errors. 
updating the rootNode's type check to BaseSelectStatement instead of SelectStatement fixes the issue.